### PR TITLE
feat: allow env variables on schema registry url and ksql url

### DIFF
--- a/kafkashell/data/shell-config.schema
+++ b/kafkashell/data/shell-config.schema
@@ -141,7 +141,7 @@
                             "examples": [
                                 "http://localhost:8081"
                             ],
-                            "pattern": "^https?://(.*)$"
+                            "pattern": "^https?://(.*)$|^\\$.*$"
                         },
                         "ksql_server_url": {
                             "type": "string",
@@ -151,7 +151,7 @@
                             "examples": [
                                 "http://localhost:8088"
                             ],
-                            "pattern": "^https?://(.*)$"
+                            "pattern": "^https?://(.*)$|^\\$.*$"
                         },
                         "command_prefix": {
                             "type": "string",

--- a/tests/data/test-environment-variables-config.yaml
+++ b/tests/data/test-environment-variables-config.yaml
@@ -1,0 +1,22 @@
+version: 1
+enable:
+  history: true
+  save_on_exit: true
+  auto_complete: true
+  auto_suggest: true
+  inline_help: true
+  fuzzy_search: true
+cluster: local
+clusters:
+  local:
+    bootstrap_servers: $BOOTSTRAP_SERVERS
+    zookeeper_connect: $ZOOKEEPER_CONNECT
+    schema_registry_url: $SCHEMA_REGISTRY_URL
+    ksql_server_url: $KSQL_SERVER_URL
+    command_prefix: ''
+  test:
+    bootstrap_servers: test:9092
+    zookeeper_connect: test:2181
+    schema_registry_url: https://test:8081
+    ksql_server_url: https://test:8088
+    command_prefix: ''

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,8 @@
-import json
 import os
 import sys
 
 import mock
+import oyaml as yaml
 import pytest
 
 from tests.context import kafkashell
@@ -137,14 +137,27 @@ def test_get_config(mock_expanduser, test_input, expected):
 @mock.patch(print_patch_name)
 @mock.patch("sys.exit")
 @pytest.mark.parametrize("test_input,expected", test_config_data)
-def test_validate_config_invalid(mock_exit, mock_print, test_input, expected):
+def test_validate_config_valid(mock_exit, mock_print, test_input, expected):
     with open("tests/data/test-config.yaml") as f:
-        config = json.load(f)
+        config = yaml.safe_load(f)
         returned_config = kafkashell.config.validate_config(config)
 
-        assert config == returned_config
         assert not mock_print.called
         assert not mock_exit.called
+        assert config == returned_config
+
+
+@mock.patch(print_patch_name)
+@mock.patch("sys.exit")
+@pytest.mark.parametrize("test_input,expected", test_config_data)
+def test_validate_config_is_valid_with_environment_variables(mock_exit, mock_print, test_input, expected):
+    with open("tests/data/test-environment-variables-config.yaml") as f:
+        config = yaml.safe_load(f)
+        returned_config = kafkashell.config.validate_config(config)
+
+        assert not mock_print.called
+        assert not mock_exit.called
+        assert config == returned_config
 
 
 @mock.patch(print_patch_name)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -66,6 +66,11 @@ def test_default_config_schema():
     validate_schema(json_value, "shell-config", "Default user config")
 
 
+def test_environment_variable_config_schema():
+    json_value = get_test_config("test-environment-variables")
+    validate_schema(json_value, "shell-config", "Environment variable user config")
+
+
 def test_invalid_configs():
     json_value = get_test_config("test-invalid-ksql")
     message = validate_invalid_schema(json_value, "shell-config")


### PR DESCRIPTION
Allow environment variables on schema registry url and ksql server url within the configuration. 