### PR TITLE
feat: add support for command file extensions

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -58,16 +58,17 @@ Clusters can be defined to run commands against. Commands automatically add flag
 
 Each cluster should have a unique name (a key in the `clusters` root-level object). By default, the cluster `local` is added.
 
-| key                     | type         | description                                                   |
-|-------------------------|--------------|---------------------------------------------------------------|
-| `bootstrap_servers`     | string       | Comma-separated `host:port` Kafka brokers to connect to.      |
-| `zookeeper_connect`     | string       | Comma-separated `host:port` Zookeeper nodes to connect to.    |
-| `schema_registry_url`   | string       | Schema Registry URL used when working with avro schemas.      |
-| `ksql_server_url`       | string       | KSQL Server URL used when utilizing the `ksql` command.       |
-| `command_prefix`        | string       | Prefix all commands with another command, i.e. 'docker exec'. |
-| `consumer_settings`     | ToolSettings | Pass config and default property settings to consumer CLIs.   |
-| `producer_settings`     | ToolSettings | Pass config and default property settings to producer CLIs.   |
-| `admin_client_settings` | ToolSettings | Pass config to admin clients through `--command-config`.   |
+| key                      | type         | description                                                   |
+|--------------------------|--------------|---------------------------------------------------------------|
+| `bootstrap_servers`      | string       | Comma-separated `host:port` Kafka brokers to connect to.      |
+| `zookeeper_connect`      | string       | Comma-separated `host:port` Zookeeper nodes to connect to.    |
+| `schema_registry_url`    | string       | Schema Registry URL used when working with avro schemas.      |
+| `ksql_server_url`        | string       | KSQL Server URL used when utilizing the `ksql` command.       |
+| `command_prefix`         | string       | Prefix all commands with another command, i.e. 'docker exec'. |
+| `command_file_extension` | string       | Add a file extension such as `sh` to commands.                |
+| `consumer_settings`      | ToolSettings | Pass config and default property settings to consumer CLIs.   |
+| `producer_settings`      | ToolSettings | Pass config and default property settings to producer CLIs.   |
+| `admin_client_settings`  | ToolSettings | Pass config to admin clients through `--command-config`.      |
 
 
 #### Tool Settings
@@ -142,6 +143,34 @@ docker exec -it kafka-tools kafka-broker-api-versions --bootstrap-server docker:
 
 As you can see, you can save a ton of typing time by utilizing `kafka-shell`!
 
+### Command File Extension
+
+The file extension for commands such as `kafka-topics` is `null` by default. Depending on how you installed the kafka command-line tools, they may have the extension `sh` or `bat`. They may also be set this way in pre-built docker images.
+
+You can change this, per cluster, by setting the `command_file_extension` property in the cluster config. For example:
+
+```yaml
+...
+clusters:
+  local:
+    bootstrap_servers: localhost:9092
+    zookeeper_connect: localhost:2181
+    schema_registry_url: http://localhost:8081
+    ksql_server_url: http://localhost:8088
+    command_file_extension: sh
+```
+
+If you run `kafka-topics --list` with the above command, the following would be run:
+
+```bash
+kafka-topics.sh --list --zookeeper localhost:2181
+```
+
+Without the file extension config set, the following would be run:
+
+```bash
+kafka-topics --list --zookeeper localhost:2181
+```
 
 ## Support
 If you have a question on how to configure `kafka-shell`, feel free to [open a support issue][support].

--- a/kafkashell/data/shell-config.schema
+++ b/kafkashell/data/shell-config.schema
@@ -163,6 +163,17 @@
                             ],
                             "pattern": "^(.*)$"
                         },
+                        "command_file_extension": {
+                            "type": "string",
+                            "title": "Command File Extension",
+                            "description": "Add a file extension such as '.sh' or .bat' to the commands.",
+                            "default": "",
+                            "examples": [
+                                "sh",
+                                "bat"
+                            ],
+                            "pattern": "^sh$|^bat$"
+                        },
                         "consumer_settings": {
                             "type": "object",
                             "title": "Consumer Settings",

--- a/kafkashell/executor.py
+++ b/kafkashell/executor.py
@@ -16,9 +16,9 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import sys
 
+import os
 from prompt_toolkit import shortcuts
 
 from kafkashell import constants
@@ -117,11 +117,21 @@ class Executor:
         else:
             final_command = command
 
+        final_command = self.handle_file_extension(final_command)
+
         if self.check_for_valid_command_prefix():
             command_prefix = self.settings.get_cluster_details()["command_prefix"].strip()
             final_command = "{0} {1}".format(command_prefix, final_command)
 
         os.system(final_command)
+
+    def handle_file_extension(self, command):
+        file_extension = self.get_file_extension()
+        if file_extension is not None:
+            split_command = command.split(" ")
+            split_command[0] = "{}.{}".format(split_command[0], file_extension)
+            return " ".join(split_command)
+        return command
 
     def execute_cluster_command(self, command):
         split_text = command.split(" ")
@@ -327,6 +337,12 @@ class Executor:
         return "command_prefix" in self.settings.get_cluster_details() \
                and \
                len(self.settings.get_cluster_details()["command_prefix"]) > 0
+
+    def get_file_extension(self):
+        try:
+            return self.settings.get_cluster_details()["command_file_extension"]
+        except KeyError:
+            return None
 
     @staticmethod
     def wrap_with_spaces(string):

--- a/tests/data/test-file-extension-bat-config.yaml
+++ b/tests/data/test-file-extension-bat-config.yaml
@@ -1,0 +1,17 @@
+version: 1
+enable:
+  history: true
+  save_on_exit: true
+  auto_complete: true
+  auto_suggest: true
+  inline_help: true
+  fuzzy_search: true
+cluster: local
+clusters:
+  local:
+    bootstrap_servers: localhost:9092
+    zookeeper_connect: localhost:2181
+    schema_registry_url: http://localhost:8081
+    ksql_server_url: http://localhost:8088
+    command_prefix: ''
+    command_file_extension: bat

--- a/tests/data/test-file-extension-sh-config.yaml
+++ b/tests/data/test-file-extension-sh-config.yaml
@@ -1,0 +1,17 @@
+version: 1
+enable:
+  history: true
+  save_on_exit: true
+  auto_complete: true
+  auto_suggest: true
+  inline_help: true
+  fuzzy_search: true
+cluster: local
+clusters:
+  local:
+    bootstrap_servers: localhost:9092
+    zookeeper_connect: localhost:2181
+    schema_registry_url: http://localhost:8081
+    ksql_server_url: http://localhost:8088
+    command_prefix: ''
+    command_file_extension: sh

--- a/tests/data/test-invalid-file-extension-config.yaml
+++ b/tests/data/test-invalid-file-extension-config.yaml
@@ -1,0 +1,17 @@
+version: 1
+enable:
+  history: true
+  save_on_exit: true
+  auto_complete: true
+  auto_suggest: true
+  inline_help: true
+  fuzzy_search: true
+cluster: local
+clusters:
+  local:
+    bootstrap_servers: localhost:9092
+    zookeeper_connect: localhost:2181
+    schema_registry_url: http://localhost:8081
+    ksql_server_url: http://localhost:8088
+    command_prefix: ''
+    command_file_extension: asdf

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -591,6 +591,24 @@ prefix_none_test_data = [
     ("   ksql   ", "ksql -- http://localhost:8088"),
 ]
 
+command_file_extension_sh_test_data = [
+    ("kafka-topics --list", "kafka-topics.sh --list --zookeeper localhost:2181"),
+    ("kafka-console-consumer", "kafka-console-consumer.sh --bootstrap-server localhost:9092"),
+    (
+        "kafka-consumer-groups --to-offset 10 --list",
+        "kafka-consumer-groups.sh --to-offset 10 --list --bootstrap-server localhost:9092"
+    )
+]
+
+command_file_extension_bat_test_data = [
+    ("kafka-topics --list", "kafka-topics.bat --list --zookeeper localhost:2181"),
+    ("kafka-console-consumer", "kafka-console-consumer.bat --bootstrap-server localhost:9092"),
+    (
+        "kafka-consumer-groups --to-offset 10 --list",
+        "kafka-consumer-groups.bat --to-offset 10 --list --bootstrap-server localhost:9092"
+    )
+]
+
 command_prefix_test_data = [
     ({}, False),
     ({"command_prefix": ""}, False),
@@ -697,6 +715,30 @@ def test_executor_command_prefix(mock_config_path, mock_os_system, test_input, e
 @pytest.mark.parametrize("test_input,expected", prefix_none_test_data)
 def test_executor_command_prefix_none(mock_config_path, mock_os_system, test_input, expected):
     mock_config_path.return_value = setup_config_path_for_test("test-prefix-none")
+
+    executor = kafkashell.executor.Executor(kafkashell.settings.Settings())
+    executor.execute(test_input)
+
+    mock_os_system.assert_called_once_with(expected)
+
+
+@mock.patch('os.system')
+@mock.patch('kafkashell.config.get_user_config_path')
+@pytest.mark.parametrize("test_input,expected", command_file_extension_sh_test_data)
+def test_executor_command_file_extension_sh(mock_config_path, mock_os_system, test_input, expected):
+    mock_config_path.return_value = setup_config_path_for_test("test-file-extension-sh")
+
+    executor = kafkashell.executor.Executor(kafkashell.settings.Settings())
+    executor.execute(test_input)
+
+    mock_os_system.assert_called_once_with(expected)
+
+
+@mock.patch('os.system')
+@mock.patch('kafkashell.config.get_user_config_path')
+@pytest.mark.parametrize("test_input,expected", command_file_extension_bat_test_data)
+def test_executor_command_file_extension_bat(mock_config_path, mock_os_system, test_input, expected):
+    mock_config_path.return_value = setup_config_path_for_test("test-file-extension-bat")
 
     executor = kafkashell.executor.Executor(kafkashell.settings.Settings())
     executor.execute(test_input)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -79,3 +79,9 @@ def test_invalid_configs():
     json_value = get_test_config("test-invalid-schema-registry")
     message = validate_invalid_schema(json_value, "shell-config")
     assert message is not None
+
+
+def test_invalid_file_extension():
+    json_value = get_test_config("test-invalid-file-extension")
+    message = validate_invalid_schema(json_value, "shell-config")
+    assert message is not None


### PR DESCRIPTION
Adds support for file extensions such as `sh` and `bat` on commands such as `kafka-topics`. 

Related:
- Issue #18 
- Issue #15 